### PR TITLE
Store import history after ranking file import

### DIFF
--- a/app/models/import_history.rb
+++ b/app/models/import_history.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+#
+# Model for storing the history of ranking file imports
+#
+class ImportHistory < ApplicationRecord
+  CATEGORIES = %w[Herren Damen Junioren Juniorinnen].freeze
+
+  validates :filename, presence: true
+  validates :category, presence: true, inclusion: { in: CATEGORIES }
+  validates :period, presence: true
+  validates :imported_at, presence: true
+end

--- a/app/models/ranking.rb
+++ b/app/models/ranking.rb
@@ -16,6 +16,12 @@ class Ranking < ApplicationRecord
     category = file_category_from_filename(file)
     store_rankings_from_csv(file, period, AGE_GROUP_MAP[category])
     calculate_rankings(period, GENDER_FACTORS[category]) if GENDER_FACTORS.key?(category)
+    ImportHistory.create!(
+      filename: File.basename(file),
+      category: category.to_s.capitalize,
+      period: period,
+      imported_at: Time.current
+    )
     elapsed_ms = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) - start_ms
     logger.info "import of '#{File.basename(file)}' completed in #{elapsed_ms}ms"
   end

--- a/db/migrate/20260508120000_create_import_histories.rb
+++ b/db/migrate/20260508120000_create_import_histories.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Migration to create the import_histories table
+class CreateImportHistories < ActiveRecord::Migration[8.1]
+  def change
+    create_table :import_histories do |t|
+      t.string :filename, null: false
+      t.string :category, null: false
+      t.date :period, null: false
+      t.datetime :imported_at, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2022_07_20_150031) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_08_120000) do
+  create_table "import_histories", force: :cascade do |t|
+    t.string "category", null: false
+    t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.datetime "imported_at", null: false
+    t.date "period", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "rankings", force: :cascade do |t|
     t.string "age_group"
     t.boolean "age_group_ranking", default: false


### PR DESCRIPTION
## Summary
- Adds `import_histories` table via migration to persist filename, category, period, and import timestamp
- Adds `ImportHistory` model with presence and category inclusion validations
- Updates `Ranking.import_rankings` to create an `ImportHistory` record after each successful import

Closes #148