### PR TITLE
Prevent duplicate ranking file imports

### DIFF
--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -25,15 +25,13 @@ class ImportController < ApplicationController
   def upload; end
 
   def import
-    if params[:file]
-      uploaded = params[:file]
-      safe_filename = File.basename(uploaded.original_filename)
-      File.binwrite(Rails.root.join('public', 'uploads', safe_filename), uploaded.read)
-      Ranking.import_rankings("public/uploads/#{safe_filename}")
-      redirect_to status_url, flash: { info: "new rankings file #{safe_filename} imported!" }
-    else
-      redirect_to status_url, flash: { info: 'please upload a ranking file' }
-    end
+    return redirect_to status_url, flash: { info: 'please upload a ranking file' } unless params[:file]
+
+    uploaded = params[:file]
+    safe_filename = File.basename(uploaded.original_filename)
+    File.binwrite(Rails.root.join('public', 'uploads', safe_filename), uploaded.read)
+    Ranking.import_rankings("public/uploads/#{safe_filename}")
+    redirect_to status_url, flash: { info: "new rankings file #{safe_filename} imported!" }
   rescue Ranking::DuplicateImportError => e
     redirect_to status_url, flash: { danger: e.message }
   end

--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -34,6 +34,8 @@ class ImportController < ApplicationController
     else
       redirect_to status_url, flash: { info: 'please upload a ranking file' }
     end
+  rescue Ranking::DuplicateImportError => e
+    redirect_to status_url, flash: { danger: e.message }
   end
 
   private

--- a/app/models/ranking.rb
+++ b/app/models/ranking.rb
@@ -10,10 +10,16 @@ class Ranking < ApplicationRecord
   GENDER_FACTORS = { junioren: 100, juniorinnen: 200 }.freeze
   AGE_GROUP_MAP = { herren: 'm00', damen: 'w00', junioren: 'overall', juniorinnen: 'overall' }.freeze
 
+  class DuplicateImportError < StandardError; end
+
   def self.import_rankings(file)
     start_ms = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
     period = extract_period_from_filename(file)
     category = file_category_from_filename(file)
+    if ImportHistory.exists?(category: category.to_s.capitalize, period: period)
+      raise DuplicateImportError, "rankings for '#{category}' / #{period} have already been imported"
+    end
+
     store_rankings_from_csv(file, period, AGE_GROUP_MAP[category])
     calculate_rankings(period, GENDER_FACTORS[category]) if GENDER_FACTORS.key?(category)
     ImportHistory.create!(

--- a/db/migrate/20260508120743_backfill_import_histories_from_rankings.rb
+++ b/db/migrate/20260508120743_backfill_import_histories_from_rankings.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Backfills import_histories for ranking data imported before the table existed.
 class BackfillImportHistoriesFromRankings < ActiveRecord::Migration[8.1]
   CATEGORY_MAPPINGS = [
     { category: 'Herren',      age_group: 'm00',     dtb_range: nil },
@@ -9,30 +10,37 @@ class BackfillImportHistoriesFromRankings < ActiveRecord::Migration[8.1]
   ].freeze
 
   def up
-    created = 0
-
-    CATEGORY_MAPPINGS.each do |mapping|
-      scope = Ranking.where(age_group: mapping[:age_group])
-      scope = scope.where(dtb_id: mapping[:dtb_range]) if mapping[:dtb_range]
-
-      scope.select(:date).distinct.each do |record|
-        period = record.date
-        next if ImportHistory.exists?(category: mapping[:category], period: period)
-
-        ImportHistory.create!(
-          filename: "#{mapping[:category]}_#{period.strftime('%Y%m%d')}.csv",
-          category: mapping[:category],
-          period: period,
-          imported_at: scope.where(date: period).minimum(:created_at)
-        )
-        created += 1
-      end
-    end
-
+    created = CATEGORY_MAPPINGS.sum { |mapping| backfill_category(mapping) }
     say "backfilled #{created} import history record(s)"
   end
 
   def down
     # Cannot safely distinguish backfilled records from genuine import history
+  end
+
+  private
+
+  def backfill_category(mapping)
+    scope = build_scope(mapping)
+    scope.select(:date).distinct.count do |record|
+      next if ImportHistory.exists?(category: mapping[:category], period: record.date)
+
+      create_history(mapping[:category], record.date, scope)
+      true
+    end
+  end
+
+  def build_scope(mapping)
+    scope = Ranking.where(age_group: mapping[:age_group])
+    mapping[:dtb_range] ? scope.where(dtb_id: mapping[:dtb_range]) : scope
+  end
+
+  def create_history(category, period, scope)
+    ImportHistory.create!(
+      filename: "#{category}_#{period.strftime('%Y%m%d')}.csv",
+      category: category,
+      period: period,
+      imported_at: scope.where(date: period).minimum(:created_at)
+    )
   end
 end

--- a/db/migrate/20260508120743_backfill_import_histories_from_rankings.rb
+++ b/db/migrate/20260508120743_backfill_import_histories_from_rankings.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class BackfillImportHistoriesFromRankings < ActiveRecord::Migration[8.1]
+  CATEGORY_MAPPINGS = [
+    { category: 'Herren',      age_group: 'm00',     dtb_range: nil },
+    { category: 'Damen',       age_group: 'w00',     dtb_range: nil },
+    { category: 'Junioren',    age_group: 'overall', dtb_range: 10_000_000..19_999_999 },
+    { category: 'Juniorinnen', age_group: 'overall', dtb_range: 20_000_000..29_999_999 }
+  ].freeze
+
+  def up
+    created = 0
+
+    CATEGORY_MAPPINGS.each do |mapping|
+      scope = Ranking.where(age_group: mapping[:age_group])
+      scope = scope.where(dtb_id: mapping[:dtb_range]) if mapping[:dtb_range]
+
+      scope.select(:date).distinct.each do |record|
+        period = record.date
+        next if ImportHistory.exists?(category: mapping[:category], period: period)
+
+        ImportHistory.create!(
+          filename: "#{mapping[:category]}_#{period.strftime('%Y%m%d')}.csv",
+          category: mapping[:category],
+          period: period,
+          imported_at: scope.where(date: period).minimum(:created_at)
+        )
+        created += 1
+      end
+    end
+
+    say "backfilled #{created} import history record(s)"
+  end
+
+  def down
+    # Cannot safely distinguish backfilled records from genuine import history
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_08_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_08_120743) do
   create_table "import_histories", force: :cascade do |t|
     t.string "category", null: false
     t.datetime "created_at", null: false

--- a/test/controllers/import_controller_test.rb
+++ b/test/controllers/import_controller_test.rb
@@ -16,4 +16,19 @@ class ImportControllerTest < ActionDispatch::IntegrationTest
     assert_not flash.empty?
     assert_redirected_to login_url
   end
+
+  test 'redirects with danger flash when uploading a duplicate file' do
+    ImportHistory.create!(
+      filename: 'Herren_20180401.csv',
+      category: 'Herren',
+      period: Date.new(2018, 4, 1),
+      imported_at: Time.current
+    )
+    post login_path, params: { session: { email: @user.email, password: 'password' } }
+    file = fixture_file_upload('Herren_20180401.csv', 'text/csv')
+    post import_path, params: { file: file }
+    assert_redirected_to status_url
+    assert_not_nil flash[:danger]
+    assert_match(/already been imported/, flash[:danger])
+  end
 end

--- a/test/models/ranking_test.rb
+++ b/test/models/ranking_test.rb
@@ -46,6 +46,14 @@ class RankingTest < ActiveSupport::TestCase
     assert_equal(6, sut.size)
   end
 
+  test 'raises DuplicateImportError when importing the same file twice' do
+    Ranking.import_rankings('./test/fixtures/files/Herren_20180401.csv')
+    exception = assert_raises Ranking::DuplicateImportError do
+      Ranking.import_rankings('./test/fixtures/files/Herren_20180401.csv')
+    end
+    assert_match(/herren.*already been imported/, exception.message)
+  end
+
   test 'full ranking_file_import for youth' do
     assert(File.exist?('./test/fixtures/files/Junioren_20180401.csv'))
     assert(File.exist?('./test/fixtures/files/Juniorinnen_20180401.csv'))


### PR DESCRIPTION
## Summary

- Raises `Ranking::DuplicateImportError` when a `category` + `period` combination already exists in `import_histories` before proceeding with an import
- `ImportController` rescues the error and redirects to the status page with a danger flash message
- New migration backfills `import_histories` for all previously imported ranking data, deriving category from `age_group` and `dtb_id` range

## Test plan

- [ ] Verify duplicate import is rejected with a danger flash in the UI
- [ ] Verify a fresh import still succeeds as before
- [ ] Run `bundle exec rails test` — all 44 tests pass

Closes #149