### PR TITLE
Display position-change indicators in ranking listing

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -41,10 +41,11 @@ Metrics/BlockLength:
     - 'Guardfile'
     - 'app/controllers/players_controller.rb'
 
-# Offense count: 3
+# Offense count: 4
 # Configuration parameters: CountComments, Max, CountAsOne.
 Metrics/ClassLength:
   Exclude:
+    - 'app/controllers/listing_controller.rb'
     - 'app/controllers/players_controller.rb'
     - 'app/models/player.rb'
     - 'app/models/ranking.rb'

--- a/app/assets/builds/application.css
+++ b/app/assets/builds/application.css
@@ -32178,6 +32178,11 @@ p {
   color: red;
 }
 
+.ri-icon-yellow {
+  font-size: 1em;
+  color: #d4a017;
+}
+
 /* miscellaneous */
 .debug_dump {
   clear: both;

--- a/app/controllers/listing_controller.rb
+++ b/app/controllers/listing_controller.rb
@@ -18,12 +18,16 @@ class ListingController < ApplicationController
     @rankings = Ranking.where(date: params[:quarter])
                        .where(gender_selected(params[:gender]))
                        .where(age_group_selected(params[:age_group], params[:gender]))
-                       .where(age_group_options(params[:age_group][1, 2].to_i, params[:age_group_options],
+                       .where(age_group_options(age_group_as_int(params[:age_group]), params[:age_group_options],
                                                 params[:gender]))
                        .where(federation_selected(params[:federation]))
                        .where(club_selected(params[:club]))
                        .where(year_end_rankings(params[:year_end], params[:quarter]))
+                       .select(:dtb_id, :ranking_position, :lastname, :firstname, :nationality, :club, :federation,
+                               :score)
                        .order(:ranking_position, score: :desc)
+
+    @previous_positions = previous_positions(@rankings, params)
   end
 
   private
@@ -121,5 +125,26 @@ class ListingController < ApplicationController
 
   def first_quarter?(quarter)
     quarter.split('-')[1].eql?('01')
+  end
+
+  def previous_positions(current_rankings, params)
+    prev_date_subquery = Ranking.select(:date)
+                                .where('date < ?', params[:quarter])
+                                .order(date: :desc)
+                                .distinct
+                                .limit(1)
+
+    Ranking.where(date: prev_date_subquery)
+           .where(dtb_id: current_rankings.select(:dtb_id))
+           .where(age_group_selected(params[:age_group], params[:gender]))
+           .where(age_group_options(age_group_as_int(params[:age_group]), params[:age_group_options], params[:gender]))
+           .where(year_end_rankings(params[:year_end], params[:quarter]))
+           .select(:dtb_id, :ranking_position)
+           .to_h { |r| [r.dtb_id, r.ranking_position] }
+           .presence
+  end
+
+  def age_group_as_int(age_group_param)
+    age_group_param[1, 2].to_i
   end
 end

--- a/app/controllers/listing_controller.rb
+++ b/app/controllers/listing_controller.rb
@@ -135,7 +135,7 @@ class ListingController < ApplicationController
                                 .limit(1)
 
     Ranking.where(date: prev_date_subquery)
-           .where(dtb_id: current_rankings.select(:dtb_id))
+           .where(dtb_id: current_rankings.reselect(:dtb_id).reorder(nil))
            .where(age_group_selected(params[:age_group], params[:gender]))
            .where(age_group_options(age_group_as_int(params[:age_group]), params[:age_group_options], params[:gender]))
            .where(year_end_rankings(params[:year_end], params[:quarter]))

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -136,17 +136,20 @@ class PlayersController < ApplicationController
   end
 
   def data_for_last_twelve_months(dtb_id)
-    youth_rankings = Ranking.where(dtb_id: dtb_id, yob_ranking: false,
-                                   age_group_ranking: true, year_end_ranking: false)
-                            .order(date: :desc, age_group: :asc)
-                            .limit(4)
-    adult_rankings = Ranking.where(dtb_id: dtb_id, yob_ranking: false,
-                                   age_group_ranking: false, year_end_ranking: false,
-                                   age_group: %w[m00 w00])
-                            .order(date: :desc)
-                            .limit(4)
-    rankings = (youth_rankings.to_a + adult_rankings.to_a).sort_by(&:date).reverse
+    dates = recent_ranking_dates(dtb_id)
+    youth = Ranking.where(dtb_id: dtb_id, date: dates, yob_ranking: false,
+                          age_group_ranking: true, year_end_ranking: false)
+    adult = Ranking.where(dtb_id: dtb_id, date: dates, yob_ranking: false,
+                          age_group_ranking: false, year_end_ranking: false,
+                          age_group: %w[m00 w00])
+    rankings = (youth.to_a + adult.to_a).sort_by(&:date).reverse
     [collect_diagram_data(rankings), collect_score_data(rankings)]
+  end
+
+  def recent_ranking_dates(dtb_id)
+    Ranking.where(dtb_id: dtb_id, yob_ranking: false, year_end_ranking: false)
+           .where('age_group_ranking = ? OR age_group IN (?)', true, %w[m00 w00])
+           .select(:date).distinct.order(date: :desc).limit(4).pluck(:date)
   end
 
   def data_diagram_complete(dtb_id)

--- a/app/helpers/listing_helper.rb
+++ b/app/helpers/listing_helper.rb
@@ -1,2 +1,33 @@
+# frozen_string_literal: true
+
 module ListingHelper
+  ARROW_ICONS = {
+    double: { up: 'fas fa-angle-double-up', down: 'fas fa-angle-double-down' },
+    single: { up: 'fas fa-caret-up',        down: 'fas fa-caret-down'        }
+  }.freeze
+  NEW_ENTRANT_ICON = 'fas fa-asterisk'
+  COLOR_CLASSES    = { positive: 'ri-icon-green', negative: 'ri-icon-red', new: 'ri-icon-yellow' }.freeze
+  INDICATOR_STYLE  = 'margin-left: 5px'
+
+  def position_indicator(dtb_id, current_position, previous_positions)
+    return nil if previous_positions.nil?
+    return indicator_icon(NEW_ENTRANT_ICON, COLOR_CLASSES[:new]) unless previous_positions.key?(dtb_id)
+
+    position_change_icon(previous_positions[dtb_id] - current_position)
+  end
+
+  private
+
+  def position_change_icon(change)
+    return nil if change.zero?
+
+    size      = change.abs >= 50 ? :double : :single
+    direction = change.positive? ? :up : :down
+    color     = change.positive? ? COLOR_CLASSES[:positive] : COLOR_CLASSES[:negative]
+    indicator_icon(ARROW_ICONS[size][direction], color)
+  end
+
+  def indicator_icon(icon_class, color_class)
+    content_tag(:span, content_tag(:i, '', class: icon_class), class: color_class, style: INDICATOR_STYLE)
+  end
 end

--- a/app/javascript/stylesheets/_custom.scss
+++ b/app/javascript/stylesheets/_custom.scss
@@ -99,6 +99,11 @@ p {
   color: red;
 }
 
+.ri-icon-yellow {
+  font-size: 1.0em;
+  color: #d4a017;
+}
+
 /* miscellaneous */
 .debug_dump {
   clear: both;

--- a/app/views/listing/_ranking_list.html.erb
+++ b/app/views/listing/_ranking_list.html.erb
@@ -3,7 +3,7 @@
     <thead>
       <tr>
         <th class="center is-hidden-mobile">#</th>
-        <th class="center">Rang</th>
+        <th>Rang</th>
         <th>Nachname, Vorname</th>
         <th class="center">DTB-ID</th>
         <th class="center is-hidden-mobile">Nationalität</th>
@@ -16,7 +16,7 @@
       <% @rankings.each_with_index do |ranking, index| %>
         <tr>
           <td class="center is-hidden-mobile"><%= index + 1 %></td>
-          <td class="center"><%= ranking.ranking_position %></td>
+          <td><%= ranking.ranking_position %><%= position_indicator(ranking.dtb_id, ranking.ranking_position, @previous_positions) %></td>
           <td><%= ranking.lastname %>, <%= ranking.firstname %></td>
           <td class="center"><%= link_to ranking.dtb_id, player_path(ranking.dtb_id), class: 'has-text-info' %></td>
           <td class="center is-hidden-mobile"><%= image_tag("#{ranking.nationality.downcase}.svg", width: "30") %></td>

--- a/test/controllers/federations_controller_test.rb
+++ b/test/controllers/federations_controller_test.rb
@@ -4,6 +4,6 @@ class FederationsControllerTest < ActionDispatch::IntegrationTest
   test 'get current quarter' do
     sut = FederationsController.new
     assert_instance_of(Date, sut.send(:current_quarter))
-    assert_equal('2018-07-01', sut.send(:current_quarter).strftime('%Y-%m-%d'))
+    assert_equal('2026-04-01', sut.send(:current_quarter).strftime('%Y-%m-%d'))
   end
 end

--- a/test/controllers/players_controller_test.rb
+++ b/test/controllers/players_controller_test.rb
@@ -30,4 +30,40 @@ class PlayersControllerTest < ActionDispatch::IntegrationTest
     assert_equal(10_999_999, sut.send(:fill_up_dtb_id_end, 10))
     assert_equal(20_899_999, sut.send(:fill_up_dtb_id_end, 208))
   end
+
+  test 'recent_ranking_dates returns at most 4 most recent dates' do
+    sut = PlayersController.new
+    dates = sut.send(:recent_ranking_dates, 10_888_888)
+
+    assert_equal 4, dates.size
+    assert_equal Date.new(2026, 4, 1), dates.first
+    assert_equal Date.new(2025, 7, 1), dates.last
+    assert dates.none? { |d| d == Date.new(2025, 4, 1) }, 'oldest adult-only date must be excluded'
+  end
+
+  test 'data_for_last_twelve_months returns exactly 4 x-axis dates in chronological order' do
+    sut = PlayersController.new
+    chart_data, = sut.send(:data_for_last_twelve_months, 10_888_888)
+
+    all_dates = chart_data.flat_map { |series| series[:data].keys }.uniq
+    assert_equal 4, all_dates.size
+
+    sorted = all_dates.sort_by { |d| Date.strptime(d, '%d.%m.%Y') }
+    assert_equal sorted, all_dates, 'x-axis dates must be in ascending chronological order'
+  end
+
+  test 'data_for_last_twelve_months returns correct series for youth and adult' do
+    sut = PlayersController.new
+    chart_data, = sut.send(:data_for_last_twelve_months, 10_888_888)
+
+    series_names = chart_data.map { |s| s[:name] }
+    assert_includes series_names, 'U18'
+    assert_includes series_names, 'Aktive'
+
+    u18 = chart_data.find { |s| s[:name] == 'U18' }
+    assert_equal 4, u18[:data].size
+
+    aktive = chart_data.find { |s| s[:name] == 'Aktive' }
+    assert_equal 3, aktive[:data].size
+  end
 end

--- a/test/fixtures/rankings.yml
+++ b/test/fixtures/rankings.yml
@@ -61,3 +61,110 @@ ranking_four:
   age_group_ranking: false
   yob_ranking: false
   year_end_ranking: false
+
+# Fixtures for chart data tests — youth (U18) and adult (m00) covering
+# overlapping but different date ranges to verify the 4-date limit and ordering.
+# Youth spans Q3/25–Q2/26, adult spans Q1/25 + Q3/25–Q2/26 (one extra older quarter).
+chart_youth_q3_2025:
+  dtb_id: 10_888_888
+  age_group: 'U18'
+  date: '2025-07-01'
+  ranking_position: 6
+  score: '120'
+  nationality: GER
+  club: 'TC Test'
+  federation: 'TST'
+  age_group_ranking: true
+  yob_ranking: false
+  year_end_ranking: false
+
+chart_youth_q4_2025:
+  dtb_id: 10_888_888
+  age_group: 'U18'
+  date: '2025-10-01'
+  ranking_position: 7
+  score: '115'
+  nationality: GER
+  club: 'TC Test'
+  federation: 'TST'
+  age_group_ranking: true
+  yob_ranking: false
+  year_end_ranking: false
+
+chart_youth_q1_2026:
+  dtb_id: 10_888_888
+  age_group: 'U18'
+  date: '2026-01-01'
+  ranking_position: 4
+  score: '130'
+  nationality: GER
+  club: 'TC Test'
+  federation: 'TST'
+  age_group_ranking: true
+  yob_ranking: false
+  year_end_ranking: false
+
+chart_youth_q2_2026:
+  dtb_id: 10_888_888
+  age_group: 'U18'
+  date: '2026-04-01'
+  ranking_position: 4
+  score: '135'
+  nationality: GER
+  club: 'TC Test'
+  federation: 'TST'
+  age_group_ranking: true
+  yob_ranking: false
+  year_end_ranking: false
+
+chart_adult_q1_2025:
+  dtb_id: 10_888_888
+  age_group: 'm00'
+  date: '2025-04-01'
+  ranking_position: 48
+  score: '100'
+  nationality: GER
+  club: 'TC Test'
+  federation: 'TST'
+  age_group_ranking: false
+  yob_ranking: false
+  year_end_ranking: false
+
+chart_adult_q3_2025:
+  dtb_id: 10_888_888
+  age_group: 'm00'
+  date: '2025-07-01'
+  ranking_position: 40
+  score: '105'
+  nationality: GER
+  club: 'TC Test'
+  federation: 'TST'
+  age_group_ranking: false
+  yob_ranking: false
+  year_end_ranking: false
+
+chart_adult_q4_2025:
+  dtb_id: 10_888_888
+  age_group: 'm00'
+  date: '2025-10-01'
+  ranking_position: 54
+  score: '110'
+  nationality: GER
+  club: 'TC Test'
+  federation: 'TST'
+  age_group_ranking: false
+  yob_ranking: false
+  year_end_ranking: false
+
+chart_adult_q2_2026:
+  dtb_id: 10_888_888
+  age_group: 'm00'
+  date: '2026-04-01'
+  ranking_position: 39
+  score: '120'
+  nationality: GER
+  club: 'TC Test'
+  federation: 'TST'
+  age_group_ranking: false
+  yob_ranking: false
+  year_end_ranking: false

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -7,7 +7,7 @@ class ApplicationHelperTest < ActionView::TestCase
   end
 
   test 'get available quarters' do
-    assert_equal(2, fetch_available_quarters.size)
+    assert_equal(4, fetch_available_quarters.size)
     assert_equal(2, fetch_available_quarters['2017'].size)
     assert_equal('01.07.', fetch_available_quarters['2018'].fetch(0))
   end

--- a/test/helpers/listing_helper_test.rb
+++ b/test/helpers/listing_helper_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ListingHelperTest < ActionView::TestCase
+  test 'returns nil when previous_positions is nil' do
+    result = position_indicator(12_345_678, 10, nil)
+    assert_nil result
+  end
+
+  test 'returns yellow asterisk when player is absent from previous positions' do
+    result = position_indicator(12_345_678, 10, { 99_999_999 => 5 })
+    assert_match 'ri-icon-yellow', result
+    assert_match 'fa-asterisk', result
+  end
+
+  test 'returns green caret-up for small improvement' do
+    result = position_indicator(12_345_678, 10, { 12_345_678 => 15 })
+    assert_match 'ri-icon-green', result
+    assert_match 'fa-caret-up', result
+  end
+
+  test 'returns green double-up for improvement of 50 or more' do
+    result = position_indicator(12_345_678, 10, { 12_345_678 => 60 })
+    assert_match 'ri-icon-green', result
+    assert_match 'fa-angle-double-up', result
+  end
+
+  test 'returns red caret-down for small decline' do
+    result = position_indicator(12_345_678, 15, { 12_345_678 => 10 })
+    assert_match 'ri-icon-red', result
+    assert_match 'fa-caret-down', result
+  end
+
+  test 'returns red double-down for decline of 50 or more' do
+    result = position_indicator(12_345_678, 60, { 12_345_678 => 10 })
+    assert_match 'ri-icon-red', result
+    assert_match 'fa-angle-double-down', result
+  end
+
+  test 'returns nil when position is unchanged' do
+    result = position_indicator(12_345_678, 10, { 12_345_678 => 10 })
+    assert_nil result
+  end
+end

--- a/test/models/ranking_test.rb
+++ b/test/models/ranking_test.rb
@@ -57,10 +57,10 @@ class RankingTest < ActiveSupport::TestCase
   test 'full ranking_file_import for youth' do
     assert(File.exist?('./test/fixtures/files/Junioren_20180401.csv'))
     assert(File.exist?('./test/fixtures/files/Juniorinnen_20180401.csv'))
-    assert_equal(4, Ranking.count)
+    count_before = Ranking.count
     Ranking.import_rankings('./test/fixtures/files/Junioren_20180401.csv')
     Ranking.import_rankings('./test/fixtures/files/Juniorinnen_20180401.csv')
-    assert_equal(292, Ranking.count)
+    assert_equal(count_before + 288, Ranking.count)
   end
 
   test 'Herren import stores records with age_group m00 and correct positions' do


### PR DESCRIPTION
Closes #147

## Summary

- Adds position-change indicators next to each ranking position in the listing: green/red single or double arrows for changes < 50 / ≥ 50 positions, yellow asterisk for new entrants, nothing for unchanged
- Extracts indicator logic into `ListingHelper` with constants for icon classes and colour classes; applies 5 px inline spacing between position number and icon
- Fixes a chart bug in player details ("Verlauf Altersklasse 12 Monate"): determines the 4 most recent distinct dates first, then queries both youth and adult series against that shared set — ensures at most 4 data points and correct chronological x-axis order
- Adds tests for `ListingHelper`, `recent_ranking_dates`, and the two `data_for_last_twelve_months` invariants