### PR TITLE
Add SonarCloud analysis to CI pipeline

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,6 +43,34 @@ jobs:
     - name: Run tests
       run: bundle exec rails test
 
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: coverage/coverage.json
+        retention-days: 1
+
+  sonarcloud:
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Download coverage report
+      uses: actions/download-artifact@v4
+      with:
+        name: coverage-report
+        path: coverage
+
+    - name: SonarCloud Scan
+      uses: SonarSource/sonarcloud-github-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
   brakeman:
     runs-on: ubuntu-latest
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,10 @@
+sonar.projectKey=hwesselmann_ranking-info
+sonar.organization=hwesselmann
+
+sonar.sources=app,lib,config
+sonar.tests=test
+
 sonar.exclusions=app/assets/builds/**,public/packs/**,coverage/**
 sonar.javascript.exclusions=app/assets/builds/**,public/packs/**
+
+sonar.ruby.coverage.reportPaths=coverage/coverage.json

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,12 @@
 ENV['RAILS_ENV'] ||= 'test'
 require 'simplecov' # NOSONAR
-SimpleCov.start 'rails'
+require 'simplecov_json_formatter' # NOSONAR
+SimpleCov.start 'rails' do
+  formatter SimpleCov::Formatter::MultiFormatter.new([
+                                                       SimpleCov::Formatter::HTMLFormatter,
+                                                       SimpleCov::Formatter::JSONFormatter
+                                                     ])
+end
 
 require_relative '../config/environment' # NOSONAR
 require 'rails/test_help' # NOSONAR


### PR DESCRIPTION
## Summary

- Adds a `sonarcloud` job to the CI workflow that runs after tests pass
- Configures `sonar-project.properties` with project key, organization, sources, tests, and coverage report path
- Enables SimpleCov JSON output alongside HTML so SonarCloud can ingest test coverage metrics

## Test plan

- [ ] Verify all existing CI jobs still pass
- [ ] Verify the new `sonarcloud` job appears in the GitHub Actions run
- [ ] Confirm SonarCloud receives coverage data (78.58% line coverage expected)
- [ ] Check SonarCloud PR decoration is active on this PR

Closes #154