### PR TITLE
feat: import new rankings from the filesystem (issue #159)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ target/
 
 # claude config files
 .claude/
+CLAUDE.md
 
 # Ignore key files for decrypting credentials and more.
 /config/*.key

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ COPY --chown=ruby:ruby --from=build /usr/local/bundle /usr/local/bundle
 COPY --chown=ruby:ruby . .
 COPY --chown=ruby:ruby --from=build /app/public /app/public
 
-RUN mkdir -p public/uploads tmp/pids log && \
+RUN mkdir -p public/uploads tmp/pids log storage/import && \
     chmod 0755 bin/* && \
     chmod +x entrypoint.sh
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'rails', '~> 8.0'
 gem 'rexml', '>= 3.4.2'
 gem 'rswag-api'
 gem 'rswag-ui'
+gem 'solid_queue'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,8 +112,13 @@ GEM
     drb (2.2.3)
     erb (6.0.4)
     erubi (1.13.1)
+    et-orbi (1.4.0)
+      tzinfo
     ffi (1.17.0)
     formatador (1.1.0)
+    fugit (1.12.1)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
     guard (2.18.1)
@@ -232,6 +237,7 @@ GEM
     public_suffix (6.0.1)
     puma (6.4.3)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
     rack-session (2.1.2)
@@ -352,6 +358,13 @@ GEM
       yard (~> 0.9, >= 0.9.24)
       yard-activesupport-concern (~> 0.0)
       yard-solargraph (~> 0.1)
+    solid_queue (1.4.0)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      concurrent-ruby (>= 1.3.1)
+      fugit (~> 1.11)
+      railties (>= 7.1)
+      thor (>= 1.3.1)
     sqlite3 (2.9.3-x86_64-linux-gnu)
     sqlite3 (2.9.3-x86_64-linux-musl)
     stringio (3.2.0)
@@ -416,6 +429,7 @@ DEPENDENCIES
   selenium-webdriver
   simplecov (= 0.21.2)
   solargraph
+  solid_queue
   sqlite3 (~> 2.0)
   tzinfo-data
   web-console (>= 3.3.0)

--- a/README.md
+++ b/README.md
@@ -113,9 +113,36 @@ To import data into the system, create a CSV file from the official ranking list
 
 This is the default column order Tabula produces. An example file can be found in `test/fixtures/files`.
 
-## Importing data / login credentials  
+## Scheduled filesystem import
 
-Access to the CSV upload functionality is restricted to registered users. To create an admin user:
+The application automatically scans an import folder for new CSV ranking files and imports them on a configurable schedule. The Solid Queue supervisor must be running for scheduled jobs to execute:
+
+```bash
+bin/jobs
+```
+
+**Import folder**
+
+Place ranking CSV files in the import folder. Files already recorded in the import history are skipped automatically. Files are never deleted after import.
+
+If an import fails, the error is appended to `error.log` in the import folder. Subsequent errors are separated from previous ones by a blank line.
+
+**Configuration**
+
+| Variable | Description | Default |
+|---|---|---|
+| `IMPORT_FOLDER` | Absolute path to the folder containing ranking CSV files | `storage/import/` inside the application root |
+| `IMPORT_SCHEDULE` | Cron expression for how often the folder is scanned | `0 12 * * *` (daily at 12:00) |
+
+Example with custom settings:
+
+```bash
+IMPORT_FOLDER=/data/rankings IMPORT_SCHEDULE="0 6 * * *" bin/jobs
+```
+
+## Web upload / login credentials  
+
+CSV files can also be imported manually through the web interface at `/import`. Access is restricted to registered users. To create an admin user:
 
 1. Ensure the database is up to date: `bin/rails db:migrate`
 2. Open a Rails console: `bin/rails console`

--- a/app/jobs/ranking_import_job.rb
+++ b/app/jobs/ranking_import_job.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#
+# Scheduled job that scans the import folder for new CSV ranking files and imports them.
+#
+class RankingImportJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    import_folder = ENV.fetch('IMPORT_FOLDER', Rails.root.join('storage', 'import').to_s)
+    csv_files = Dir.glob(File.join(import_folder, '*.csv'))
+
+    csv_files.each do |file_path|
+      import_file(file_path, import_folder)
+    end
+  end
+
+  private
+
+  def import_file(file_path, import_folder)
+    Ranking.import_rankings(file_path)
+    logger.info "RankingImportJob: imported '#{File.basename(file_path)}'"
+  rescue Ranking::DuplicateImportError
+    logger.info "RankingImportJob: skipping '#{File.basename(file_path)}' (already imported)"
+  rescue StandardError => e
+    write_error_log(import_folder, "#{File.basename(file_path)}: #{e.message}")
+    logger.error "RankingImportJob: error importing '#{File.basename(file_path)}': #{e.message}"
+  end
+
+  def write_error_log(import_folder, message)
+    error_log = File.join(import_folder, 'error.log')
+    separator = File.exist?(error_log) ? "\n\n" : ''
+    File.open(error_log, 'a') { |f| f.write("#{separator}#{message}") }
+  end
+end

--- a/bin/jobs
+++ b/bin/jobs
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/environment"
+require "solid_queue/cli"
+
+SolidQueue::Cli.start(ARGV)

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,8 @@ module RankingInfo
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    config.active_job.queue_adapter = :solid_queue
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,7 +68,6 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter = :resque
   # config.active_job.queue_name_prefix = "ranking_info_production"
 
   # Disable caching for Action Mailer templates even if Action Controller

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -1,0 +1,18 @@
+default: &default
+  dispatchers:
+    - polling_interval: 1
+      batch_size: 500
+  workers:
+    - queues: "*"
+      threads: 3
+      processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
+      polling_interval: 0.1
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,0 +1,14 @@
+production:
+  clear_solid_queue_finished_jobs:
+    command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
+    schedule: every hour at minute 12
+  ranking_import:
+    class: RankingImportJob
+    schedule: <%= ENV.fetch("IMPORT_SCHEDULE", "0 12 * * *") %>
+    queue: default
+
+development:
+  ranking_import:
+    class: RankingImportJob
+    schedule: <%= ENV.fetch("IMPORT_SCHEDULE", "0 12 * * *") %>
+    queue: default

--- a/db/migrate/20260510120000_create_solid_queue_tables.rb
+++ b/db/migrate/20260510120000_create_solid_queue_tables.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/ClassLength, Metrics/MethodLength, Metrics/AbcSize, Style/Documentation
+class CreateSolidQueueTables < ActiveRecord::Migration[8.0]
+  def change
+    create_table :solid_queue_jobs do |t|
+      t.string :queue_name, null: false
+      t.string :class_name, null: false
+      t.text :arguments
+      t.integer :priority, default: 0, null: false
+      t.string :active_job_id
+      t.datetime :scheduled_at
+      t.datetime :finished_at
+      t.string :concurrency_key
+      t.timestamps
+
+      t.index :active_job_id
+      t.index :class_name
+      t.index :finished_at
+      t.index %i[queue_name finished_at], name: :index_solid_queue_jobs_for_filtering
+      t.index %i[scheduled_at finished_at], name: :index_solid_queue_jobs_for_alerting
+    end
+
+    create_table :solid_queue_blocked_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.string :concurrency_key, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :created_at, null: false
+
+      t.index %i[concurrency_key priority job_id], name: :index_solid_queue_blocked_executions_for_release
+      t.index %i[expires_at concurrency_key], name: :index_solid_queue_blocked_executions_for_maintenance
+      t.index :job_id, unique: true
+    end
+
+    create_table :solid_queue_claimed_executions do |t|
+      t.bigint :job_id, null: false
+      t.bigint :process_id
+      t.datetime :created_at, null: false
+
+      t.index :job_id, unique: true
+      t.index %i[process_id job_id]
+    end
+
+    create_table :solid_queue_failed_executions do |t|
+      t.bigint :job_id, null: false
+      t.text :error
+      t.datetime :created_at, null: false
+
+      t.index :job_id, unique: true
+    end
+
+    create_table :solid_queue_pauses do |t|
+      t.string :queue_name, null: false
+      t.datetime :created_at, null: false
+
+      t.index :queue_name, unique: true
+    end
+
+    create_table :solid_queue_processes do |t|
+      t.string :kind, null: false
+      t.datetime :last_heartbeat_at, null: false
+      t.bigint :supervisor_id
+      t.integer :pid, null: false
+      t.string :hostname
+      t.text :metadata
+      t.datetime :created_at, null: false
+      t.string :name, null: false
+
+      t.index :last_heartbeat_at
+      t.index %i[name supervisor_id], unique: true
+      t.index :supervisor_id
+    end
+
+    create_table :solid_queue_ready_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.datetime :created_at, null: false
+
+      t.index :job_id, unique: true
+      t.index %i[priority job_id], name: :index_solid_queue_poll_all
+      t.index %i[queue_name priority job_id], name: :index_solid_queue_poll_by_queue
+    end
+
+    create_table :solid_queue_recurring_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :task_key, null: false
+      t.datetime :run_at, null: false
+      t.datetime :created_at, null: false
+
+      t.index :job_id, unique: true
+      t.index %i[task_key run_at], unique: true
+    end
+
+    create_table :solid_queue_recurring_tasks do |t|
+      t.string :key, null: false
+      t.string :schedule, null: false
+      t.string :command, limit: 2048
+      t.string :class_name
+      t.text :arguments
+      t.string :queue_name
+      t.integer :priority, default: 0
+      t.boolean :static, default: true, null: false
+      t.text :description
+      t.timestamps
+
+      t.index :key, unique: true
+      t.index :static
+    end
+
+    create_table :solid_queue_scheduled_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.datetime :scheduled_at, null: false
+      t.datetime :created_at, null: false
+
+      t.index :job_id, unique: true
+      t.index %i[scheduled_at priority job_id], name: :index_solid_queue_dispatch_all
+    end
+
+    create_table :solid_queue_semaphores do |t|
+      t.string :key, null: false
+      t.integer :value, default: 1, null: false
+      t.datetime :expires_at, null: false
+      t.timestamps
+
+      t.index :expires_at
+      t.index %i[key value]
+      t.index :key, unique: true
+    end
+
+    add_foreign_key :solid_queue_blocked_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_claimed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_failed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_ready_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_recurring_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_scheduled_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+  end
+  # rubocop:enable Metrics/ClassLength, Metrics/MethodLength, Metrics/AbcSize, Style/Documentation
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_08_120743) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_10_120000) do
   create_table "import_histories", force: :cascade do |t|
     t.string "category", null: false
     t.datetime "created_at", null: false
@@ -46,6 +46,127 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_120743) do
     t.index ["lastname"], name: "index_rankings_on_lastname"
   end
 
+  create_table "solid_queue_blocked_executions", force: :cascade do |t|
+    t.string "concurrency_key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_claimed_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+  end
+
+  create_table "solid_queue_failed_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "error"
+    t.bigint "job_id", null: false
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_jobs", force: :cascade do |t|
+    t.string "active_job_id"
+    t.text "arguments"
+    t.string "class_name", null: false
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "finished_at"
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.datetime "scheduled_at"
+    t.datetime "updated_at", null: false
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
+  end
+
+  create_table "solid_queue_pauses", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "queue_name", null: false
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  end
+
+  create_table "solid_queue_processes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "hostname"
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.text "metadata"
+    t.string "name", null: false
+    t.integer "pid", null: false
+    t.bigint "supervisor_id"
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
+  end
+
+  create_table "solid_queue_ready_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
+  end
+
+  create_table "solid_queue_recurring_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.datetime "run_at", null: false
+    t.string "task_key", null: false
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_recurring_tasks", force: :cascade do |t|
+    t.text "arguments"
+    t.string "class_name"
+    t.string "command", limit: 2048
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "key", null: false
+    t.integer "priority", default: 0
+    t.string "queue_name"
+    t.string "schedule", null: false
+    t.boolean "static", default: true, null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
+  end
+
+  create_table "solid_queue_scheduled_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.datetime "scheduled_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
+  end
+
+  create_table "solid_queue_semaphores", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.string "key", null: false
+    t.datetime "updated_at", null: false
+    t.integer "value", default: 1, null: false
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email"
@@ -54,4 +175,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_120743) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
+
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
 end

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,4 +7,7 @@ if [ -f tmp/pids/server.pid ]; then
 fi
 
 bundle exec rails db:migrate
+
+bin/jobs start &
+
 bundle exec rails s -b 0.0.0.0 -p 3000

--- a/test/jobs/ranking_import_job_test.rb
+++ b/test/jobs/ranking_import_job_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RankingImportJobTest < ActiveSupport::TestCase
+  HERREN_FIXTURE = Rails.root.join('test/fixtures/files/Herren_20180401.csv').to_s
+
+  setup do
+    @import_dir = Dir.mktmpdir
+    @original_import_folder = ENV.fetch('IMPORT_FOLDER', nil)
+    ENV['IMPORT_FOLDER'] = @import_dir
+  end
+
+  teardown do
+    FileUtils.rm_rf(@import_dir)
+    ENV['IMPORT_FOLDER'] = @original_import_folder
+  end
+
+  test 'does nothing when import folder contains no CSV files' do
+    assert_no_difference 'ImportHistory.count' do
+      RankingImportJob.new.perform
+    end
+    refute File.exist?(File.join(@import_dir, 'error.log'))
+  end
+
+  test 'imports a new CSV file and creates an ImportHistory record' do
+    FileUtils.cp(HERREN_FIXTURE, @import_dir)
+    assert_difference 'ImportHistory.count', 1 do
+      RankingImportJob.new.perform
+    end
+  end
+
+  test 'skips already-imported files without creating an error log' do
+    FileUtils.cp(HERREN_FIXTURE, @import_dir)
+    ImportHistory.create!(filename: 'Herren_20180401.csv', category: 'Herren',
+                          period: Date.new(2018, 4, 1), imported_at: Time.current)
+    RankingImportJob.new.perform
+    refute File.exist?(File.join(@import_dir, 'error.log'))
+  end
+
+  test 'creates error.log when an import fails due to an unrecognized file category' do
+    FileUtils.cp(HERREN_FIXTURE, File.join(@import_dir, 'Invalid_20180401.csv'))
+    RankingImportJob.new.perform
+    assert File.exist?(File.join(@import_dir, 'error.log'))
+  end
+
+  test 'error.log contains the filename and the error message' do
+    FileUtils.cp(HERREN_FIXTURE, File.join(@import_dir, 'Invalid_20180401.csv'))
+    RankingImportJob.new.perform
+    content = File.read(File.join(@import_dir, 'error.log'))
+    assert_includes content, 'Invalid_20180401.csv'
+  end
+
+  test 'appends to existing error.log with a blank line separator' do
+    FileUtils.cp(HERREN_FIXTURE, File.join(@import_dir, 'Invalid_20180401.csv'))
+    FileUtils.cp(HERREN_FIXTURE, File.join(@import_dir, 'Bogus_20180401.csv'))
+    RankingImportJob.new.perform
+    content = File.read(File.join(@import_dir, 'error.log'))
+    assert content.include?("\n\n"), 'error.log entries should be separated by a blank line'
+  end
+end


### PR DESCRIPTION
## Summary

- Adds **Solid Queue** as ActiveJob adapter (single database, migration-based setup)
- New **`RankingImportJob`** scans a configurable import folder for CSV files, skips already-imported files, and appends errors with blank-line separators to `error.log`
- Recurring task runs daily at 12:00 by default; schedule and folder are configurable via env vars (`IMPORT_SCHEDULE`, `IMPORT_FOLDER`)
- Web upload (`/import`) remains available alongside the new flow
- Dockerfile and `entrypoint.sh` updated so the Solid Queue supervisor starts automatically alongside the web server
- README documents the new import flow

## Configuration

| Variable | Default | Description |
|---|---|---|
| `IMPORT_FOLDER` | `storage/import/` | Path to the folder containing ranking CSV files |
| `IMPORT_SCHEDULE` | `0 12 * * *` | Cron expression for the scan interval |

## Test plan

- [x] 6 new job integration tests pass (`bin/rails test test/jobs/ranking_import_job_test.rb`)
- [x] Full test suite passes with no failures (`bin/rails test`)
- [x] Rubocop reports no offenses (`bundle exec rubocop`)
- [x] Place a ranking CSV in `storage/import/`, start `bin/jobs`, verify ImportHistory record is created
- [x] Place the same file again, verify it is skipped without creating `error.log`
- [x] Place a file with an unrecognised category prefix, verify `error.log` is created