### PR TITLE
Add REST player endpoints and HAL links to listings

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -52,6 +52,7 @@ Metrics/ClassLength:
     - 'app/models/player.rb'
     - 'app/models/ranking.rb'
     - 'test/controllers/api/v1/listings_controller_test.rb'
+    - 'test/controllers/api/v1/players_controller_test.rb'
 
 # Offense count: 4
 # Configuration parameters: AllowedMethods, AllowedPatterns, Max.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,34 @@ api:
 
 Subsequent requests made through the Swagger UI will include the token automatically.
 
+### Bruno Collection
+
+A [Bruno](https://www.usebruno.com/) collection for manual API testing is located in the `bruno/` directory. Open the folder in Bruno, select the **local** environment, and set your `apiToken`. All three endpoints are pre-configured; optional query parameters are included but disabled and can be toggled per request.
+
+### Available Endpoints
+
+#### Listings
+
+```
+GET /api/v1/listings/:quarter/:age_group_slug
+```
+
+Returns a paginated ranking list for a given quarter and age group. Each entry includes a HAL-style `links.self` pointing to the player detail endpoint. See `/api-docs` for all query parameters (federation, club, pagination, etc.).
+
+#### Players
+
+```
+GET /api/v1/players?lastname=Mustermann&yob=2008
+```
+
+Searches for players by lastname (case-insensitive, partial match). The optional `yob` parameter (year of birth, YYYY) narrows results to players born in that year. Returns 400 if `lastname` is missing, 404 if no match is found.
+
+```
+GET /api/v1/players/:dtb_id
+```
+
+Returns basic player data and the full quarterly ranking history across all age groups. Returns 404 if the DTB ID is unknown.
+
 ## Import file format  
 
 To import data into the system, create a CSV file from the official ranking list PDF using a tool like Tabula. The file must be in the format:

--- a/app/controllers/api/v1/listings_controller.rb
+++ b/app/controllers/api/v1/listings_controller.rb
@@ -99,7 +99,10 @@ module Api
       def serialize_ranking(ranking, prev_positions)
         prev_position = prev_positions[ranking.dtb_id]
         position_change = prev_position ? prev_position - ranking.ranking_position : nil
-        ranking_attrs(ranking).merge(position_change: position_change)
+        ranking_attrs(ranking).merge(
+          position_change: position_change,
+          links: { self: api_v1_player_url(ranking.dtb_id) }
+        )
       end
 
       def ranking_attrs(ranking)

--- a/app/controllers/api/v1/players_controller.rb
+++ b/app/controllers/api/v1/players_controller.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # Provides player search and detail endpoints.
+    #
+    # Routes:
+    #   GET /api/v1/players?lastname=...&yob=...   — search by lastname (+ optional year of birth)
+    #   GET /api/v1/players/:id                    — player detail with full ranking history
+    class PlayersController < Api::V1::BaseController
+      def index
+        return render json: { error: 'lastname parameter required' }, status: :bad_request if params[:lastname].blank?
+
+        players = search_players
+        return render json: { error: 'Not Found' }, status: :not_found if players.empty?
+
+        render json: {
+          request: search_request_block(players.size),
+          data: players.map { |p| serialize_player_summary(p) }
+        }
+      end
+
+      def show
+        rankings = Ranking.where(dtb_id: params[:id], yob_ranking: false, age_group_ranking: false,
+                                 year_end_ranking: false)
+                          .order(date: :desc, age_group: :asc)
+        return render json: { error: 'Not Found' }, status: :not_found if rankings.empty?
+
+        current = rankings.first
+        render json: { data: player_data(current, rankings) }
+      end
+
+      private
+
+      def search_players
+        if params[:yob].present?
+          yob_male = params[:yob].to_s[2, 4].to_i + 100
+          Player.find_players_by_lastname_and_yob(params[:lastname], yob_male, yob_male + 100)
+        else
+          Player.find_players_by_lastname(params[:lastname])
+        end
+      end
+
+      def player_data(current, rankings)
+        {
+          dtb_id: current.dtb_id,
+          lastname: current.lastname,
+          firstname: current.firstname,
+          nationality: current.nationality,
+          club: current.club,
+          federation: current.federation,
+          rankings: rankings.map { |r| serialize_ranking_history_entry(r) }
+        }
+      end
+
+      def serialize_player_summary(player)
+        {
+          dtb_id: player.dtb_id,
+          lastname: player.lastname,
+          firstname: player.firstname,
+          club: player.club,
+          links: { self: api_v1_player_url(player.dtb_id) }
+        }
+      end
+
+      def search_request_block(total_count)
+        { lastname: params[:lastname], yob: params[:yob].presence, total_count: total_count }
+      end
+
+      def serialize_ranking_history_entry(ranking)
+        {
+          quarter: ranking.date,
+          age_group: ranking.age_group,
+          ranking_position: ranking.ranking_position,
+          score: ranking.score
+        }
+      end
+    end
+  end
+end

--- a/app/views/static_pages/_impressum.html.erb
+++ b/app/views/static_pages/_impressum.html.erb
@@ -1,13 +1,13 @@
 <span class="text-xl font-bold">Impressum</span>
 <p>Angaben gemäß § 5 TMG</p>
-<p><%= ENV["IMPRINT_NAME"] || CONFIG['imprint_name'] %><br/>
-    <%= ENV["IMPRINT_STREET"] || CONFIG['imprint_street'] %><br/>
-    <%= ENV["IMPRINT_ZIPCODE"] || CONFIG['imprint_zipcode'] %> <%= ENV["IMPRINT_CITY"] || CONFIG['imprint_city'] %><br/>
+<p><%= ENV["IMPRINT_NAME"] %><br/>
+    <%= ENV["IMPRINT_STREET"] %><br/>
+    <%= ENV["IMPRINT_ZIPCODE"] %> <%= ENV["IMPRINT_CITY"] %><br/>
 </p>
 <p><strong>Vertreten durch: </strong><br/>
-  <%= ENV["IMPRINT_NAME"] || CONFIG['imprint_name'] %><br/>
+  <%= ENV["IMPRINT_NAME"] %><br/>
 </p>
 <p><strong>Kontakt:</strong><br/>
-  Telefon: <%= ENV["IMPRINT_PHONE"] || CONFIG['imprint_phone'] %><br>
-  E-Mail: <%= ENV["IMPRINT_MAIL"] || CONFIG['imprint_mail'] %><br/>
+  Telefon: <%= ENV["IMPRINT_PHONE"] %><br>
+  E-Mail: <%= ENV["IMPRINT_MAIL"] %><br/>
 </p>

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -10,6 +10,6 @@
   aktuellen Fassung unter<br/><a href="https://www.tennis.de/spielen/ranglisten-und-leistungsklasse.html" target="_blank">https://www.tennis.de/spielen/ranglisten-und-leistungsklasse.html</a><br/>abrufbar ist.
 </p>
 <p>
-  Die Adresse unserer Website ist: <%= ENV.fetch("DOMAIN") || CONFIG['domain'] %>.<br/><br/>
+  Die Adresse unserer Website ist: <%= ENV["DOMAIN"] %>.<br/><br/>
   <%= render 'impressum' %>
 </p>

--- a/bruno/bruno.json
+++ b/bruno/bruno.json
@@ -1,0 +1,6 @@
+{
+  "version": "1",
+  "name": "Ranking Info API",
+  "type": "collection",
+  "ignore": []
+}

--- a/bruno/environments/local.bru
+++ b/bruno/environments/local.bru
@@ -1,0 +1,8 @@
+vars {
+  baseUrl: http://localhost:3000
+  apiToken: your-secret-token
+}
+
+vars:secret [
+  apiToken
+]

--- a/bruno/listings/get-listings.bru
+++ b/bruno/listings/get-listings.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Get Listings
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/v1/listings/2026-04-01/m00
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{apiToken}}
+}
+
+params:query {
+  page: 1
+  per_page: 25
+  ~federation: BAD
+  ~club: TC Musterclub
+  ~age_group_options: only_yob
+  ~year_end: 0
+}

--- a/bruno/players/get-player-detail.bru
+++ b/bruno/players/get-player-detail.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get Player Detail
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/v1/players/10712345
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{apiToken}}
+}

--- a/bruno/players/search-players.bru
+++ b/bruno/players/search-players.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Search Players
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/v1/players
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{apiToken}}
+}
+
+params:query {
+  lastname: Mustermann
+  ~yob: 2008
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get 'listings/:quarter/:age_group_slug', to: 'listings#index', as: :listings
+      resources :players, only: %i[index show]
     end
   end
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -42,6 +42,16 @@ components:
       description: API token configured via Rails credentials (api.tokens) or ENV[API_BEARER_TOKEN]
 
   schemas:
+    PlayerLinks:
+      type: object
+      description: HAL-style hypermedia links
+      properties:
+        self:
+          type: string
+          format: uri
+          description: URL of the player detail resource
+          example: /api/v1/players/10712345
+
     RankingEntry:
       type: object
       properties:
@@ -81,6 +91,109 @@ components:
             Change in position compared to the previous quarter.
             Positive = moved up, negative = moved down, null = no previous entry.
           example: 2
+        links:
+          $ref: '#/components/schemas/PlayerLinks'
+
+    PlayerSummary:
+      type: object
+      description: Condensed player record returned by the search endpoint
+      properties:
+        dtb_id:
+          type: integer
+          example: 10712345
+        lastname:
+          type: string
+          example: Mustermann
+        firstname:
+          type: string
+          example: Max
+        club:
+          type: string
+          example: TC Musterclub
+        links:
+          $ref: '#/components/schemas/PlayerLinks'
+
+    RankingHistoryEntry:
+      type: object
+      description: One ranking entry in a player's history
+      properties:
+        quarter:
+          type: string
+          format: date
+          description: First day of the ranking quarter
+          example: "2026-04-01"
+        age_group:
+          type: string
+          description: Age group slug (e.g. m00, U18)
+          example: m00
+        ranking_position:
+          type: integer
+          example: 1
+        score:
+          type: string
+          example: "1234"
+
+    PlayerDetail:
+      type: object
+      description: Full player record including ranking history
+      properties:
+        dtb_id:
+          type: integer
+          example: 10712345
+        lastname:
+          type: string
+          example: Mustermann
+        firstname:
+          type: string
+          example: Max
+        nationality:
+          type: string
+          maxLength: 3
+          example: GER
+        club:
+          type: string
+          example: TC Musterclub
+        federation:
+          type: string
+          example: BAD
+        rankings:
+          type: array
+          items:
+            $ref: '#/components/schemas/RankingHistoryEntry'
+
+    SearchRequestBlock:
+      type: object
+      description: Echo of the applied search parameters plus total result count
+      properties:
+        lastname:
+          type: string
+          description: The lastname search term as submitted
+          example: Mustermann
+        yob:
+          type: string
+          nullable: true
+          description: Year of birth filter as submitted, null if not provided
+          example: "2008"
+        total_count:
+          type: integer
+          description: Total number of matching players
+          example: 3
+
+    PlayersSearchResponse:
+      type: object
+      properties:
+        request:
+          $ref: '#/components/schemas/SearchRequestBlock'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlayerSummary'
+
+    PlayerDetailResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/PlayerDetail'
 
     RequestBlock:
       type: object
@@ -266,6 +379,129 @@ paths:
 
         "401":
           description: Unauthorized — missing or invalid Bearer token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/players:
+    get:
+      summary: Search players by lastname
+      description: >
+        Returns players whose lastname matches the search term (case-insensitive, partial match).
+        An optional `yob` (year of birth, YYYY) further narrows the results.
+        Returns 404 when no matching player is found.
+      operationId: searchPlayers
+      tags:
+        - Players
+      parameters:
+        - name: lastname
+          in: query
+          required: true
+          description: Lastname to search for (partial, case-insensitive)
+          schema:
+            type: string
+          example: Mustermann
+
+        - name: yob
+          in: query
+          required: false
+          description: Year of birth (YYYY) to narrow results
+          schema:
+            type: string
+            pattern: '^\d{4}$'
+          example: "2008"
+
+      responses:
+        "200":
+          description: One or more matching players found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlayersSearchResponse'
+              example:
+                data:
+                  - dtb_id: 10712345
+                    lastname: Mustermann
+                    firstname: Max
+                    club: TC Musterclub
+                    links:
+                      self: /api/v1/players/10712345
+
+        "400":
+          description: Bad request — lastname parameter missing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        "401":
+          description: Unauthorized — missing or invalid Bearer token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        "404":
+          description: No player found for the given search criteria
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/players/{id}:
+    get:
+      summary: Retrieve player detail by DTB ID
+      description: >
+        Returns basic player data and the full ranking history across all age groups
+        (regular quarterly rankings only; year-end, YOB, and age-group-ranking entries are excluded).
+        Returns 404 when the DTB ID is unknown.
+      operationId: getPlayer
+      tags:
+        - Players
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: DTB ID of the player
+          schema:
+            type: integer
+          example: 10712345
+
+      responses:
+        "200":
+          description: Player found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlayerDetailResponse'
+              example:
+                data:
+                  dtb_id: 10712345
+                  lastname: Mustermann
+                  firstname: Max
+                  nationality: GER
+                  club: TC Musterclub
+                  federation: BAD
+                  rankings:
+                    - quarter: "2026-04-01"
+                      age_group: m00
+                      ranking_position: 1
+                      score: "1234"
+                    - quarter: "2025-10-01"
+                      age_group: m00
+                      ranking_position: 3
+                      score: "1100"
+
+        "401":
+          description: Unauthorized — missing or invalid Bearer token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        "404":
+          description: Player not found
           content:
             application/json:
               schema:

--- a/test/controllers/api/v1/players_controller_test.rb
+++ b/test/controllers/api/v1/players_controller_test.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Api
+  module V1
+    class PlayersControllerTest < ActionDispatch::IntegrationTest
+      TEST_TOKEN = 'test-api-token'
+      AUTH_HEADER = { 'Authorization' => "Bearer #{TEST_TOKEN}" }.freeze
+
+      setup do
+        ENV['API_BEARER_TOKEN'] = TEST_TOKEN
+      end
+
+      teardown do
+        ENV.delete('API_BEARER_TOKEN')
+      end
+
+      # --- Authentication ---
+
+      test 'index returns 401 without authorization header' do
+        get api_v1_players_path, params: { lastname: 'Mustermann' }
+        assert_response :unauthorized
+      end
+
+      test 'show returns 401 without authorization header' do
+        get api_v1_player_path(10_001_001)
+        assert_response :unauthorized
+      end
+
+      # --- Search (index) ---
+
+      test 'index returns 400 when lastname is missing' do
+        get api_v1_players_path, headers: AUTH_HEADER
+        assert_response :bad_request
+        assert_equal 'lastname parameter required', response_json['error']
+      end
+
+      test 'index returns 404 when no player matches lastname' do
+        get api_v1_players_path, headers: AUTH_HEADER, params: { lastname: 'NichtVorhanden' }
+        assert_response :not_found
+      end
+
+      test 'index returns matching players by lastname' do
+        get api_v1_players_path, headers: AUTH_HEADER, params: { lastname: 'Mustermann' }
+        assert_response :success
+        data = response_json['data']
+        assert(data.any? { |p| p['dtb_id'] == 10_001_001 })
+      end
+
+      test 'index response contains request and data keys' do
+        get api_v1_players_path, headers: AUTH_HEADER, params: { lastname: 'Mustermann' }
+        json = response_json
+        assert json.key?('request'), 'response must have a request block'
+        assert json.key?('data'), 'response must have a data array'
+      end
+
+      test 'index request block reflects query parameters' do
+        get api_v1_players_path, headers: AUTH_HEADER, params: { lastname: 'Mustermann', yob: '2000' }
+        block = response_json['request']
+        assert_equal 'Mustermann', block['lastname']
+        assert_equal '2000', block['yob']
+        assert block.key?('total_count')
+      end
+
+      test 'index request block total_count matches result size' do
+        get api_v1_players_path, headers: AUTH_HEADER, params: { lastname: 'Mustermann' }
+        json = response_json
+        assert_equal json['data'].size, json['request']['total_count']
+      end
+
+      test 'index request block yob is null when not provided' do
+        get api_v1_players_path, headers: AUTH_HEADER, params: { lastname: 'Mustermann' }
+        assert_nil response_json['request']['yob']
+      end
+
+      test 'index data entry contains required fields' do
+        get api_v1_players_path, headers: AUTH_HEADER, params: { lastname: 'Mustermann' }
+        player = response_json['data'].first
+        %w[dtb_id lastname firstname club links].each do |field|
+          assert player.key?(field), "search result must contain #{field}"
+        end
+        assert player['links'].key?('self'), 'links must contain self'
+      end
+
+      test 'index self link points to player detail endpoint' do
+        get api_v1_players_path, headers: AUTH_HEADER, params: { lastname: 'Mustermann' }
+        self_link = response_json['data'].first['links']['self']
+        assert_match %r{/api/v1/players/10001001}, self_link
+      end
+
+      test 'index filters by lastname case-insensitively' do
+        get api_v1_players_path, headers: AUTH_HEADER, params: { lastname: 'mustermann' }
+        assert_response :success
+        assert(response_json['data'].any? { |p| p['lastname'] == 'Mustermann' })
+      end
+
+      test 'index filters by yob when provided' do
+        # dtb_id 10_001_001 → male range starting at 10_000_000, yob key 100 → year 2000
+        get api_v1_players_path, headers: AUTH_HEADER, params: { lastname: 'Mustermann', yob: '2000' }
+        assert_response :success
+        assert(response_json['data'].any? { |p| p['dtb_id'] == 10_001_001 })
+      end
+
+      test 'index returns 404 when yob does not match any player' do
+        get api_v1_players_path, headers: AUTH_HEADER, params: { lastname: 'Mustermann', yob: '1990' }
+        assert_response :not_found
+      end
+
+      # --- Detail (show) ---
+
+      test 'show returns 404 for unknown dtb_id' do
+        get api_v1_player_path(99_999_999), headers: AUTH_HEADER
+        assert_response :not_found
+      end
+
+      test 'show returns player data for known dtb_id' do
+        get api_v1_player_path(10_001_001), headers: AUTH_HEADER
+        assert_response :success
+        data = response_json['data']
+        assert_equal 10_001_001, data['dtb_id']
+        assert_equal 'Mustermann', data['lastname']
+        assert_equal 'Max', data['firstname']
+      end
+
+      test 'show result contains required fields' do
+        get api_v1_player_path(10_001_001), headers: AUTH_HEADER
+        data = response_json['data']
+        %w[dtb_id lastname firstname nationality club federation rankings].each do |field|
+          assert data.key?(field), "player detail must contain #{field}"
+        end
+      end
+
+      test 'show rankings contain required fields' do
+        get api_v1_player_path(10_001_001), headers: AUTH_HEADER
+        ranking = response_json['data']['rankings'].first
+        %w[quarter age_group ranking_position score].each do |field|
+          assert ranking.key?(field), "ranking entry must contain #{field}"
+        end
+      end
+
+      test 'show returns multiple ranking entries across age groups' do
+        # Fixtures: api_herren_q2_2026_first (m00), api_herren_q1_2026_first (m00),
+        #           api_mustermann_u18_q1_2026 (U18, age_group_ranking: true → excluded)
+        get api_v1_player_path(10_001_001), headers: AUTH_HEADER
+        rankings = response_json['data']['rankings']
+        assert rankings.size >= 2
+      end
+
+      test 'show excludes age_group_ranking special entries' do
+        get api_v1_player_path(10_001_001), headers: AUTH_HEADER
+        # api_mustermann_u18_q1_2026 has age_group_ranking: true — must not appear
+        rankings = response_json['data']['rankings']
+        assert_not(rankings.any? { |r| r['age_group'] == 'U18' })
+      end
+
+      private
+
+      def response_json
+        JSON.parse(response.body)
+      end
+    end
+  end
+end

--- a/test/fixtures/rankings.yml
+++ b/test/fixtures/rankings.yml
@@ -247,6 +247,22 @@ fed_youth_m_u14_wtb:
   yob_ranking: false
   year_end_ranking: false
 
+# Player API fixtures — Mustermann (10_001_001) with a youth entry for multi-age-group history test
+api_mustermann_u18_q1_2026:
+  firstname: Max
+  lastname: Mustermann
+  nationality: GER
+  club: 'TC Testclub'
+  federation: 'BAD'
+  age_group: 'U18'
+  date: '2026-01-01'
+  ranking_position: 5
+  score: '300'
+  dtb_id: 10_001_001
+  age_group_ranking: true
+  yob_ranking: false
+  year_end_ranking: false
+
 fed_youth_w_u16_bad:
   firstname: Anna
   lastname: Badnerin


### PR DESCRIPTION
Closes #158

## Summary

- New `GET /api/v1/players?lastname=...&yob=...` endpoint — searches players by lastname with optional year-of-birth filter; returns a request block (echo of inputs + total_count) and a data array with HAL self-links
- New `GET /api/v1/players/:id` endpoint — returns basic player data and the full quarterly ranking history across all age groups (special ranking types excluded)
- `GET /api/v1/listings/...` now embeds `links.self` in every entry pointing to the corresponding player detail URL
- Both new endpoints require Bearer token auth and return 404 for unknown resources; search returns 400 when `lastname` is missing
- Fixes imprint page crash when `DOMAIN`/`IMPRINT_*` env vars are not set locally (`ENV.fetch` → `ENV[]`, removed dead `CONFIG` references)

## What's included

- `Api::V1::PlayersController` with `index` and `show` actions
- 20 new controller tests covering auth, search, yob filtering, detail, field presence, and exclusion of special ranking entries
- OpenAPI spec updated with `PlayerSummary`, `PlayerDetail`, `RankingHistoryEntry`, `SearchRequestBlock`, and `PlayerLinks` schemas plus two new paths
- Bruno collection under `bruno/` for manual testing of all three endpoints
- README updated with endpoint overview and Bruno collection hint

## Test plan

- [x] `bin/rails test` passes (128 runs, 0 failures)
- [x] `bundle exec rubocop` passes with no new offenses
- [x] Bruno collection opens in Bruno, local environment configured, all three requests return expected responses
- [x] Listings response includes `links.self` for each entry
- [x] Player search returns 400 without `lastname`, 404 for no match, 200 with request block and data array
- [x] Player detail returns 404 for unknown DTB ID, 200 with rankings array excluding age_group/yob/year_end special entries